### PR TITLE
Make blacklist an optional setting in the Titlegiver plugin

### DIFF
--- a/plugins/titlegiver/titlegiver.py
+++ b/plugins/titlegiver/titlegiver.py
@@ -56,6 +56,8 @@ class Titlegiver(plugin.Plugin):
 
     def started(self, settings):
         self.settings = json.loads(settings)
+        if "blacklist" not in self.settings:
+            self.settings["blacklist"] = []
 
     def process(self, url, server, channel):
 


### PR DESCRIPTION
The default setting generated for Titlegiver is simply:

`"titlegiver": {}`

This however fails in Titlegiver.process when checking

`if parts.netloc in self.settings["blacklist"]`

So, let's just make the setting optional.