### PR TITLE
Make feed an optional setting in the Feedretriever plugin

### DIFF
--- a/plugins/feedretriever/feedretriever.py
+++ b/plugins/feedretriever/feedretriever.py
@@ -111,6 +111,8 @@ class Feedretriever(plugin.Plugin):
         self.settings = json.loads(settings)
 
         logging.info("Feedretriever.started %s", self.settings)
+        if "feeds" not in self.settings:
+            self.settings["feeds"] = []
         for feed in self.settings["feeds"]:
             self.add_feed(feed, new=False)
 


### PR DESCRIPTION
It's automatically created when adding/saving feeds, but we don't need to require it if it's empty.