### PR TITLE
Add base-ref and head-ref to Dependency Review action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4
+        with:
+          base-ref: ${{ github.event.pull_request.base.sha || 'main' }}
+          head-ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reference: https://github.com/actions/dependency-review-action/issues/456

This should (hopefully) set the correct base-ref and head-ref for both pull_request and merge.