### PR TITLE
Utils: Silence exceptions in auto_requests.py

### DIFF
--- a/utils/auto_requests.py
+++ b/utils/auto_requests.py
@@ -3,6 +3,8 @@ import html.parser
 import httpx
 import re
 
+import logging
+
 from datetime import datetime
 from email.message import Message
 
@@ -87,7 +89,11 @@ def get(url, *args, **kwargs):
 
     with httpx.Client(http2=True, headers=final_headers, verify=final_verify) as client:
         while True:
-            response = client.get(url, follow_redirects=True)
+            try:
+                response = client.get(url, follow_redirects=True)
+            except Exception as e:
+                logging.info("Exception: " + type(e).__name__)
+                return ""
             content_type = response.headers.get("content-type", "")
             # Should we consider removing this?
             if not content_type.startswith("text/html"):


### PR DESCRIPTION
httpx.Client.get will throw a ReadTimeout exception (default timeout is 5 seconds) if there is no response.
This exception shouldn't really hurt but I don't want to clutter the output with a long exception for a known (and maybe even expected) event, so let's just print it to the log and do a silent return.

This exception is very easy to test by just loading up the Titlegiver plugin and feed it a non-routable address, like 10.255.255.1. 