### PR TITLE
Core: Fix potential memory leak in Plugin._thread()

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -79,12 +79,15 @@ class Plugin:
         logging.info("Plugin._thread %r", function)
 
         def starter():
-            context = zmq.Context()
+            context = zmq.Context.instance()
             sock = context.socket(zmq.PUSH)
             sock.connect("ipc://" + self.socket_base_path + "/ipc_plugin_" + self.name + "_workers")
             self.threading_data.call_socket = sock
 
-            function(*args, **kwargs)
+            try:
+                function(*args, **kwargs)
+            finally:
+                sock.close()
 
         thread = threading.Thread(target=starter)
         thread.start()


### PR DESCRIPTION
I think we're leaking resources here.  Calling zmq.Context() creates a new context every time it's being called and that context is never cleaned up.  Instead, we should reuse the context instance.

Also making sure to close the socket once we're done with the thread.