### PR TITLE
Core: Suppress output when running unit tests

### DIFF
--- a/plugins/wolfram/test/test_wolfram.py
+++ b/plugins/wolfram/test/test_wolfram.py
@@ -78,8 +78,9 @@ class WolframTest(unittest.TestCase):
         mock_response.content = b"<invalid>xml"
         mock_get.return_value = mock_response
 
-        answer = wolfram.get_answer("any query", "dummy_key")
-        self.assertIsNone(answer)
+        with self.assertLogs("root"):
+            answer = wolfram.get_answer("any query", "dummy_key")
+            self.assertIsNone(answer)
 
 
 if __name__ == "__main__":

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -41,8 +41,9 @@ class TestBot(unittest.TestCase):
     # Test that the Bot doesn't initialize if a bad settings is given:
     @patch("bot.settings")
     def test_bot_initialization_error(self, mock_settings):
-        with self.assertRaises(SystemExit):
-            bot = self.create_bot(mock_settings, False)
+        with self.assertLogs("root"):
+            with self.assertRaises(SystemExit):
+                bot = self.create_bot(mock_settings, False)
 
     # Test that the Bot.load_plugin method adds a plugin if everything is correct
     @patch("bot.settings")
@@ -64,7 +65,8 @@ class TestBot(unittest.TestCase):
         self, mock_spawn, mock_isfile, mock_plugin_interface, mock_settings
     ):
         bot = self.create_bot(mock_settings)
-        bot.load_plugin("test", {})
+        with self.assertLogs("root"):
+            bot.load_plugin("test", {})
         mock_plugin_interface.assert_not_called()
         self.assertEqual(len(bot.plugins), 0)
 
@@ -86,7 +88,8 @@ class TestBot(unittest.TestCase):
         connection.connect = AsyncMock()
 
         bot = self.create_bot(mock_settings)
-        self.loop.run_until_complete(bot.reconnect(connection))
+        with self.assertLogs("root"):
+            self.loop.run_until_complete(bot.reconnect(connection))
 
         self.assertEqual(connection.connect.call_count, 2)
 
@@ -189,7 +192,8 @@ class TestPluginInterface(unittest.IsolatedAsyncioTestCase):
         # Simulate process not exiting
         mock_waitpid.return_value = (0, 0)
 
-        await plugin.shutdown_plugin()
+        with self.assertLogs("root", level="ERROR"), patch("sys.stderr"):
+            await plugin.shutdown_plugin()
 
         plugin._call.assert_called_with("shutdown")
         self.assertEqual(mock_waitpid.call_count, 5)


### PR DESCRIPTION
Before:
```
$ poetry run python -m unittest discover
....................................................ERROR:root:Unable to query or parse Wolfram response
Traceback (most recent call last):
  File "/home/reggna/src/platinumshrimp/plugins/wolfram/wolfram.py", line 22, in get_answer
    root = ET.fromstring(response.content)
  File "/usr/lib64/python3.14/xml/etree/ElementTree.py", line 1353, in XML
    return parser.close()
           ~~~~~~~~~~~~^^
xml.etree.ElementTree.ParseError: no element found: line 1, column 12
......ERROR:root:Error parsing settings
.ERROR:root:Unable to load plugin test
..ERROR:root:Waiting 30 seconds to reconnect
ERROR:root:Waiting 30 seconds to reconnect
....ERROR:root:Plugin testplugin did not shut down cleanly, sending SIGTERM
Error: Plugin testplugin did not shut down cleanly, sending SIGTERM
..............................
----------------------------------------------------------------------
Ran 95 tests in 0.802s

OK
```

After:
```
$ poetry run python -m unittest discover
...............................................................................................
----------------------------------------------------------------------
Ran 95 tests in 0.810s

OK
```
